### PR TITLE
Added namespace to build.gradle and updated gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,14 @@ group 'jp.co.funseek.flutter_app_badge_control'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '2.0.20'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.0'
+        classpath 'com.android.tools.build:gradle:8.4.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -26,6 +26,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 31
+    namespace "jp.co.funseek.flutter_app_badge_control"
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Fixed a compilation error with `flutter build apk`.

>  FAILURE: Build failed with an exception.
>  * What went wrong:
>  A problem occurred configuring project ':flutter_app_badge_control'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
>  Namespace not specified. Specify a namespace in the module's build file. See https://d.android.com/r/tools/upgrade assistant/set-namespace for information about setting the namespace.